### PR TITLE
Fix windows support

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ containing a value from the following table, or `null`.
 | ------- | ----------------------------------- | -------------------------------- |
 | Linux   | `$XDG_CACHE_HOME` or `$HOME`/.cache | /home/justjavac/.cache           |
 | macOS   | `$HOME`/Library/Caches              | /Users/justjavac/Library/Caches  |
-| Windows | `{FOLDERID_LocalAppData}`           | C:\Users\justjavac\AppData\Local |
+| Windows | `$LOCALAPPDATA`                     | C:\Users\justjavac\AppData\Local |
 
 ## Usage
 

--- a/mod.ts
+++ b/mod.ts
@@ -7,7 +7,7 @@
  * | ------- | ----------------------------------- | -------------------------------- |
  * | Linux   | `$XDG_CACHE_HOME` or `$HOME`/.cache | /home/justjavac/.cache           |
  * | macOS   | `$HOME`/Library/Caches              | /Users/justjavac/Library/Caches  |
- * | Windows | `{FOLDERID_LocalAppData}`           | C:\Users\justjavac\AppData\Local |
+ * | Windows | `$LOCALAPPDATA`                     | C:\Users\justjavac\AppData\Local |
  */
 export default function cacheDir(): string | null {
   switch (Deno.build.os) {
@@ -27,7 +27,7 @@ export default function cacheDir(): string | null {
     }
 
     case "windows":
-      return Deno.env.get("FOLDERID_LocalAppData") ?? null;
+      return Deno.env.get("LOCALAPPDATA") ?? null;
   }
 
   return null;


### PR DESCRIPTION
Windows support is broken in this module, with the same problem fixed in https://github.com/justjavac/deno_dirs/pull/4. I've ported that PR's changes to this module.

(Is this repo meant to be superseded by https://github.com/justjavac/deno_dirs, or vice versa?)